### PR TITLE
feat(eslint): update `eslint-plugin-vitest` to `@vitest/eslint-plugin`

### DIFF
--- a/eslint.js
+++ b/eslint.js
@@ -281,7 +281,7 @@ export const config = [
 				files: testFiles,
 				ignores: [...playwrightFiles],
 				plugins: {
-					vitest: (await import('eslint-plugin-vitest')).default,
+					vitest: (await import('@vitest/eslint-plugin')).default,
 				},
 				rules: {
 					// you don't want the editor to autofix this, but we do want to be

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,12 @@
 			"license": "MIT",
 			"dependencies": {
 				"@total-typescript/ts-reset": "^0.6.1",
+				"@vitest/eslint-plugin": "^1.1.7",
 				"eslint-plugin-import-x": "^4.3.1",
 				"eslint-plugin-jest-dom": "^5.4.0",
 				"eslint-plugin-react": "^7.37.1",
 				"eslint-plugin-react-hooks": "^5.0.0",
 				"eslint-plugin-testing-library": "^6.3.0",
-				"eslint-plugin-vitest": "^0.5.4",
 				"globals": "^15.11.0",
 				"prettier-plugin-tailwindcss": "^0.6.8",
 				"tslib": "^2.7.0",
@@ -484,6 +484,25 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@vitest/eslint-plugin": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.1.7.tgz",
+			"integrity": "sha512-pTWGW3y6lH2ukCuuffpan6kFxG6nIuoesbhMiQxskyQMRcCN5t9SXsKrNHvEw3p8wcCsgJoRqFZVkOTn6TjclA==",
+			"peerDependencies": {
+				"@typescript-eslint/utils": ">= 8.0",
+				"eslint": ">= 8.57.0",
+				"typescript": ">= 5.0.0",
+				"vitest": "*"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				},
+				"vitest": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/acorn": {
@@ -1465,154 +1484,6 @@
 			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"engines": {
 				"node": ">=4.0"
-			}
-		},
-		"node_modules/eslint-plugin-vitest": {
-			"version": "0.5.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-vitest/-/eslint-plugin-vitest-0.5.4.tgz",
-			"integrity": "sha512-um+odCkccAHU53WdKAw39MY61+1x990uXjSPguUCq3VcEHdqJrOb8OTMrbYlY6f9jAKx7x98kLVlIe3RJeJqoQ==",
-			"dependencies": {
-				"@typescript-eslint/utils": "^7.7.1"
-			},
-			"engines": {
-				"node": "^18.0.0 || >= 20.0.0"
-			},
-			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
-				"vitest": "*"
-			},
-			"peerDependenciesMeta": {
-				"@typescript-eslint/eslint-plugin": {
-					"optional": true
-				},
-				"vitest": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/scope-manager": {
-			"version": "7.18.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
-			"integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
-			"dependencies": {
-				"@typescript-eslint/types": "7.18.0",
-				"@typescript-eslint/visitor-keys": "7.18.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/types": {
-			"version": "7.18.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
-			"integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "7.18.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
-			"integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
-			"dependencies": {
-				"@typescript-eslint/types": "7.18.0",
-				"@typescript-eslint/visitor-keys": "7.18.0",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"minimatch": "^9.0.4",
-				"semver": "^7.6.0",
-				"ts-api-utils": "^1.3.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/utils": {
-			"version": "7.18.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
-			"integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
-			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.4.0",
-				"@typescript-eslint/scope-manager": "7.18.0",
-				"@typescript-eslint/types": "7.18.0",
-				"@typescript-eslint/typescript-estree": "7.18.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^8.56.0"
-			}
-		},
-		"node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "7.18.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
-			"integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
-			"dependencies": {
-				"@typescript-eslint/types": "7.18.0",
-				"eslint-visitor-keys": "^3.4.3"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/eslint-plugin-vitest/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-vitest/node_modules/eslint-visitor-keys": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint-plugin-vitest/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
   "license": "MIT",
   "dependencies": {
     "@total-typescript/ts-reset": "^0.6.1",
+    "@vitest/eslint-plugin": "^1.1.7",
     "eslint-plugin-import-x": "^4.3.1",
     "eslint-plugin-jest-dom": "^5.4.0",
     "eslint-plugin-react": "^7.37.1",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-testing-library": "^6.3.0",
-    "eslint-plugin-vitest": "^0.5.4",
     "globals": "^15.11.0",
     "prettier-plugin-tailwindcss": "^0.6.8",
     "tslib": "^2.7.0",


### PR DESCRIPTION
`eslint-plugin-vitest` is no longer maintained because the [original maintainer has lost access to their old npm account](https://github.com/vitest-dev/eslint-plugin-vitest/issues/537).