### PR TITLE
feat(eslint): support *.spec.* files for Vitest

### DIFF
--- a/eslint.js
+++ b/eslint.js
@@ -17,7 +17,7 @@ const hasReact = has('react')
 const hasTestingLibrary = has('@testing-library/dom')
 const hasJestDom = has('@testing-library/jest-dom')
 const hasVitest = has('vitest')
-const vitestFiles = ['**/__tests__/**/*', '**/*.test.*']
+const vitestFiles = ['**/__tests__/**/*', '**/*.test.*', '**/*.spec.*']
 const testFiles = ['**/tests/**', '**/#tests/**', ...vitestFiles]
 const playwrightFiles = ['**/e2e/**']
 
@@ -224,8 +224,8 @@ export const config = [
 		: null,
 
 	// This assumes test files are those which are in the test directory or have
-	// *.test.* in the filename. If a file doesn't match this assumption, then it
-	// will not be allowed to import test files.
+	// *.test.* or *.spec.* in the filename. If a file doesn't match this assumption,
+	// then it will not be allowed to import test files.
 	{
 		files: ['**/*.ts?(x)', '**/*.js?(x)'],
 		ignores: testFiles,

--- a/fixture/app/components/accordion.spec.tsx
+++ b/fixture/app/components/accordion.spec.tsx
@@ -1,0 +1,1 @@
+export const MockAccordion = () => <div>Accordion</div>

--- a/fixture/app/components/accordion.tsx
+++ b/fixture/app/components/accordion.tsx
@@ -1,4 +1,7 @@
 // eslint-disable-next-line
 import { MockAccordion } from './__tests__/accordion.tsx'
+// eslint-disable-next-line
+import { MockAccordion as SpecMockAccordion } from './accordion.spec.tsx'
 
 console.log(MockAccordion)
+console.log(SpecMockAccordion)


### PR DESCRIPTION
By default, Vitest [includes all `.spec` files](https://vitest.dev/config/#include) as well as `.test` files so I've added this to the `vitestFiles` array to make sure they're configured correctly too.

I've added a "test" to the `fixture` app and ESLint errors about it not being possible to import from the `.spec` file in there.

