### PR TITLE
Add tsconfigRootDir definition to eslint config

### DIFF
--- a/eslint.js
+++ b/eslint.js
@@ -132,6 +132,7 @@ export const config = [
 					parser: (await import('typescript-eslint')).parser,
 					parserOptions: {
 						projectService: true,
+						tsconfigRootDir: import.meta.dirname,
 					},
 				},
 				plugins: {


### PR DESCRIPTION
On my current project I am using the epicweb eslint configuration. My main editor of choice is Helix and without tsconfigRootDir defined the following error is thrown by the vscode-eslint LSP for every tsx file that I open: `Parsing error: [/complete/filepath/index.tsx] was not found by the project service. Consider either including it in the tsconfig.json or including it in allowDefaultProject`

Here is the typescript-eslint doc page that I pulled this from: [https://typescript-eslint.io/getting-started/typed-linting/](https://typescript-eslint.io/getting-started/typed-linting/)