### PR TITLE
feat(eslint): ignore the output files of `vitest --coverage`

### DIFF
--- a/eslint.js
+++ b/eslint.js
@@ -31,6 +31,7 @@ export const config = [
 			'**/playwright-report/**',
 			'**/server-build/**',
 			'**/dist/**',
+			'**/coverage/**',
 		],
 	},
 


### PR DESCRIPTION
When running `vitest --coverage`, it outputs a bunch of JS to `./coverage` so this PR adds that directory to the ignore list

