### PR TITLE
docs: fix type annotation in eslint config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ content:
 ```js
 import { config as defaultConfig } from '@epic-web/config/eslint'
 
-/** @type {import("eslint").Linter.Config} */
+/** @type {import("eslint").Linter.Config[]} */
 export default [...defaultConfig]
 ```
 


### PR DESCRIPTION
While the current annotation still provides some level of auto-completion, it needs to be corrected.

Before the fix, auto-completion mysteriously works, but the property description isn't shown on hover:
<img width="696" alt="image" src="https://github.com/user-attachments/assets/139d8ac8-3382-460a-8bfb-6f3576d5a7a6">

After the fix, everything works as expected:
<img width="696" alt="image" src="https://github.com/user-attachments/assets/19f4f7d8-89eb-4850-9d6b-6e92d65308a5">
