### PR TITLE
fix(docs): update usage of typescript reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,7 @@ Create a `tsconfig.json` file in your project root with the following content:
 ```json
 {
 	"extends": ["@epic-web/config/typescript"],
-	"include": [
-		"@epic-web/config/reset.d.ts",
-		"**/*.ts",
-		"**/*.tsx",
-		"**/*.js",
-		"**/*.jsx"
-	],
+	"include": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
 	"compilerOptions": {
 		"paths": {
 			"#app/*": ["./app/*"],
@@ -104,6 +98,12 @@ Create a `tsconfig.json` file in your project root with the following content:
 		}
 	}
 }
+```
+
+Create a `reset.d.ts` file in your project with these contents:
+
+```typescript
+import '@epic-web/config/reset.d.ts'
 ```
 
 <details>

--- a/docs/decisions/001-reset.md
+++ b/docs/decisions/001-reset.md
@@ -19,8 +19,8 @@ wouldn't want the reset to be applied.
 
 ## Decision
 
-We'll create a `reset.d.ts` file and consumers will have to include it in their
-`includes` manually.
+We'll create a `reset.d.ts` file and consumers will have to import it in their
+project manually.
 
 ## Consequences
 

--- a/reset.d.ts
+++ b/reset.d.ts
@@ -1,4 +1,3 @@
-import '@total-typescript/ts-reset'
 import '@total-typescript/ts-reset/dom'
 
 import 'react'


### PR DESCRIPTION
1. Filenames in `tsconfig.include` are resolved relative to the directory containing the `tsconfig.json` file, therefore including files from packages will not work.
2. `ts-reset/dom` already includes `ts-reset`.