### PR TITLE
feat(prettier): Add 'cva' to tailwindFunctions for improved compatibility

### DIFF
--- a/prettier.js
+++ b/prettier.js
@@ -41,7 +41,7 @@ export const config = {
 	],
 	plugins: ['prettier-plugin-tailwindcss'],
 	tailwindAttributes: ['class', 'className', 'ngClass', '.*[cC]lassName'],
-	tailwindFunctions: ['clsx', 'cn'],
+	tailwindFunctions: ['clsx', 'cn', 'cva'],
 }
 
 // this is for backward compatibility


### PR DESCRIPTION
The `cva` function is a core part of the shadcn stack, which is widely used in the Epic Stack.

This PR adds `cva` to the `tailwindFunctions` array, ensuring that Prettier properly formats Tailwind classes inside `cva`.