### PR TITLE
fix(eslint): ignore the entire `/public` directory

### DIFF
--- a/eslint.js
+++ b/eslint.js
@@ -27,7 +27,7 @@ export const config = [
 			'**/.cache/**',
 			'**/node_modules/**',
 			'**/build/**',
-			'**/public/build/**',
+			'**/public/**',
 			'**/playwright-report/**',
 			'**/server-build/**',
 			'**/dist/**',


### PR DESCRIPTION
- Fixes #22 

## Motivation

One should never lint the public directory. It's comprised mostly of generated/static assets that the developer has little control of (or won't benefit from linting, in the first place). 