### PR TITLE
fix: correct TypeScript module value and README code formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   </p>
 </div>
 
-```
+```bash
 npm install @epic-web/config
 ```
 

--- a/typescript.json
+++ b/typescript.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"isolatedModules": true,
 		"jsx": "react-jsx",
-		"module": "preserve",
+		"module": "ESNext",
 		"target": "ES2022",
 		"strict": true,
 		"skipLibCheck": true,


### PR DESCRIPTION
Changed the module value in typescript.json from "preserve" (which is not a valid TypeScript module option) to "ESNext", which is a valid value. The "preserve" value was incorrect and would cause TypeScript to not properly handle module imports.

Fixed the code block in README.md by adding a language specifier to the npm install command's code fence. Added "bash" to properly format the code block.