### PR TITLE
remove compilerOptions types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,4 @@
 {
 	"extends": "./typescript.json",
-	"include": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
-	"compilerOptions": {
-		"types": ["./reset.d.ts"]
-	}
+	"include": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"]
 }


### PR DESCRIPTION
[The `compilerOptions.types` setting overrides the default `@types` inclusion.]( https://www.typescriptlang.org/tsconfig/#types)
Although it doesn’t affect this package, it goes beyond the intended setup and may cause confusion.

Since `reset.d.ts` is already included by the `"**/*.ts"` pattern, there’s no need to explicitly add it again.
