### PR TITLE
fix: add `.tsbuildinfo` to the `ignores` list

### DIFF
--- a/eslint.js
+++ b/eslint.js
@@ -35,6 +35,7 @@ export const config = [
 			'**/server-build/**',
 			'**/dist/**',
 			'**/coverage/**',
+			'**/*.tsbuildinfo',
 		],
 	},
 


### PR DESCRIPTION
Hi! While updating one of my workshops, I noticed that eslint fails after `npm run typecheck`. The typecheck command generates `.tsbuildinfo` files that are normally ignored in Git. But because two commands come one after another on CI, eslint started validating those files and, well, failing (idk why but eslint fails dramatically with JSON files). 

This removes the `tsbuildinfo` files from linting. 

@kentcdodds I think we need to look into this config and make it inclusive rather than exclusive. So far, it seems to want to validate _everything_, so we need to cherry-pick the things we don't want. 

It makes more sense to make it _ignore everything_ and only apply itself to the files we know are in the project.

> The fact that you cannot override configs in eslint to provide different includes/ignores patterns only makes this issue worse.